### PR TITLE
fallback to legacy credentials

### DIFF
--- a/ecmwf/datastores/config.py
+++ b/ecmwf/datastores/config.py
@@ -15,18 +15,15 @@
 from __future__ import annotations
 
 import os
+import warnings
 
 SUPPORTED_API_VERSION = "v1"
 CONFIG_PREFIX = "ecmwf_datastores"
+LEGACY_RC_FILE = "~/.cdsapirc"
+LEGACY_RC_ENV_VAR = "CDSAPI_RC"
 
 
-def read_config(path: str | None = None) -> dict[str, str]:
-    if path is None:
-        path = os.getenv(
-            f"{CONFIG_PREFIX}_RC_FILE".upper(),
-            f"~/.{CONFIG_PREFIX}rc".replace("_", "").lower(),
-        )
-    path = os.path.expanduser(path)
+def _parse_config(path: str) -> dict[str, str]:
     try:
         config = {}
         with open(path) as f:
@@ -39,6 +36,46 @@ def read_config(path: str | None = None) -> dict[str, str]:
         raise
     except Exception:
         raise ValueError(f"Failed to parse {path!r} file")
+
+
+def read_config(path: str | None = None) -> dict[str, str]:
+    rc_env_var = f"{CONFIG_PREFIX}_RC_FILE".upper()
+    use_default = path is None and rc_env_var not in os.environ
+    if path is None:
+        path = os.getenv(
+            rc_env_var,
+            f"~/.{CONFIG_PREFIX}rc".replace("_", "").lower(),
+        )
+    path = os.path.expanduser(path)
+    try:
+        return _parse_config(path)
+    except FileNotFoundError:
+        # Raise if the user provided config to an rc_env_var that does not exist.
+        if not use_default:
+            raise
+
+        # If using defaults, check for legacy config file and warn the user.
+        legacy_from_env = LEGACY_RC_ENV_VAR in os.environ
+        legacy_path = os.path.expanduser(os.getenv(LEGACY_RC_ENV_VAR, LEGACY_RC_FILE))
+        if not os.path.exists(legacy_path):
+            raise
+        if legacy_from_env:
+            warnings.warn(
+                f"Using credentials from the legacy {LEGACY_RC_ENV_VAR!r} "
+                f"environment variable. Please rename it to {rc_env_var!r}. "
+                "Support for the legacy environment variable will be removed in version 2.0.",
+                UserWarning,
+                stacklevel=2,
+            )
+        else:
+            warnings.warn(
+                f"{path!r} not found; falling back to legacy credentials file "
+                f"{legacy_path!r}. Please migrate your credentials to {path!r}. "
+                "Support for the legacy credentials file will be removed in version 2.0.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return _parse_config(legacy_path)
 
 
 def get_config(key: str, config_path: str | None = None) -> str:

--- a/tests/test_01_config.py
+++ b/tests/test_01_config.py
@@ -44,6 +44,52 @@ def test_read_default_config() -> None:
         assert config.read_config() == config.read_config(str(config_path))
 
 
+def test_read_config_legacy_fallback(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    expected_config = {"url": "dummy-url", "key": "dummy-key"}
+
+    monkeypatch.delenv("ECMWF_DATASTORES_RC_FILE", raising=False)
+    monkeypatch.delenv("CDSAPI_RC", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    legacy_file = tmp_path / ".cdsapirc"
+    legacy_file.write_text("url: dummy-url\nkey: dummy-key")
+    monkeypatch.setattr(config, "LEGACY_RC_FILE", str(legacy_file))
+
+    with pytest.warns(UserWarning, match="migrate your credentials"):
+        res = config.read_config()
+    assert res == expected_config
+
+
+def test_read_config_legacy_fallback_env_var(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    expected_config = {"url": "dummy-url", "key": "dummy-key"}
+
+    monkeypatch.delenv("ECMWF_DATASTORES_RC_FILE", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    legacy_file = tmp_path / "custom-cdsapirc"
+    legacy_file.write_text("url: dummy-url\nkey: dummy-key")
+    monkeypatch.setenv("CDSAPI_RC", str(legacy_file))
+
+    with pytest.warns(UserWarning, match="ECMWF_DATASTORES_RC_FILE"):
+        res = config.read_config()
+    assert res == expected_config
+
+
+def test_read_config_no_legacy_fallback_for_explicit_path(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    legacy_file = tmp_path / ".cdsapirc"
+    legacy_file.write_text("url: dummy-url\nkey: dummy-key")
+    monkeypatch.setattr(config, "LEGACY_RC_FILE", str(legacy_file))
+
+    with pytest.raises(FileNotFoundError):
+        config.read_config(str(tmp_path / ".ecmwfdatastoresrc"))
+
+
 def test_get_config_from_configuration_file(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Description

Use legacy credentials file/env-vars to reduce resistance when migrating to this new client. Users are warned to updated their config and that support for legacy config will be dropped in the future.

FYI, working on this as I would like to add a ecmwf-datastores-client to earthkit.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
